### PR TITLE
Indexer property doc retrieval fix

### DIFF
--- a/test/DocXmlUnitTests/PropertyInfoUnitTests.cs
+++ b/test/DocXmlUnitTests/PropertyInfoUnitTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.XPath;
+using DocXmlOtherLibForUnitTests;
+using DocXmlUnitTests.TestData;
+using LoxSmoke.DocXml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Binder = Microsoft.CSharp.RuntimeBinder.Binder;
+
+#pragma warning disable CS1591
+namespace LoxSmoke.DocXmlUnitTests
+{
+    [TestClass]
+    public class PropertyInfoUnitTests : BaseTestClass
+    {
+        public PropertyInfo MyClass_ItemProperty_GetOnly;
+        public PropertyInfo MyClass_ItemProperty_GetSet;
+        public PropertyInfo MyClass_GetSetProperty;
+
+        [TestInitialize]
+        public new void Setup()
+        {
+            base.Setup();
+            MyClass_ItemProperty_GetOnly = MyClass_Type.GetProperties().FirstOrDefault(
+                mt => mt.Name == "Item" && mt.GetMethod != null && mt.SetMethod == null);
+            MyClass_ItemProperty_GetSet = MyClass_Type.GetProperties().FirstOrDefault(
+                mt => mt.Name == "Item" && mt.GetMethod != null && mt.SetMethod != null);
+            MyClass_GetSetProperty = MyClass_Type.GetProperties().FirstOrDefault(
+                mt => mt.Name == nameof(MyClass.GetSetProperty));
+
+        }
+
+        [TestMethod]
+        public void Property_Item_GetOnly()
+        {
+            var comments = Reader.GetMemberComments(MyClass_ItemProperty_GetOnly);
+            Assert.AreEqual("Property description", comments.Summary);
+        }
+
+        [TestMethod]
+        public void Property_Item_GetSet()
+        {
+            var comments = Reader.GetMemberComments(MyClass_ItemProperty_GetSet);
+            Assert.AreEqual("ItemGetSetProperty description", comments.Summary);
+        }
+
+        [TestMethod]
+        public void Property_GetSetAndCommon()
+        {
+            var comments = Reader.GetMemberComments(MyClass_GetSetProperty);
+            Assert.AreEqual("GetSetProperty comment", comments.Summary);
+        }
+    }
+}

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -135,6 +135,17 @@ namespace LoxSmoke.DocXmlUnitTests
         public int this[string parameter] { get { return 1; } }
 
         /// <summary>
+        /// ItemGetSetProperty description
+        /// </summary>
+        /// <param name="parameter">Parameter description</param>
+        /// <returns>Return value description</returns>
+        public int this[int parameter]
+        {
+            get { return 1; }
+            set { }
+        }
+
+        /// <summary>
         /// Operator description
         /// </summary>
         /// <param name="parameter">Parameter description</param>
@@ -175,6 +186,15 @@ namespace LoxSmoke.DocXmlUnitTests
             return null;
         }
 
+        /// <summary>
+        /// GetSetProperty comment
+        /// </summary>
+        /// <returns>prop return</returns>
+        public string GetSetProperty
+        {
+            get => "test";
+            set { }
+        }
     }
 }
 


### PR DESCRIPTION
XML documentation for indexer properties is different from simple ones. There is a list of parameters that is added to the XML tag. This list of parameters has to be taken into account when retrieving comments from XML file.
  