### PR TITLE
Fix generation of XML IDs for types that are arrays of generic types

### DIFF
--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -179,7 +179,7 @@ namespace LoxSmoke.DocXml
             {
                 var typeName = Regex.Replace(type.Name, "`[0-9]+", "");
 
-                var arrayString = Regex.Match(type.Name, @"[\[,\]]*&?$").Captures.OfType<Capture>().SingleOrDefault()?.Value;
+                var arrayString = Regex.Match(type.Name, @"[\[,\]]*&?$").Captures.OfType<Capture>().Single().Value;
                 typeName = typeName.Substring(0, typeName.Length - arrayString.Length);
 
                 var paramString = string.Join(",",

--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -179,7 +179,7 @@ namespace LoxSmoke.DocXml
             {
                 var typeName = Regex.Replace(type.Name, "`[0-9]+", "");
 
-                var arrayString = Regex.Match(type.Name, @"[\[,\]]*&?$").Captures.OfType<Capture>().Single().Value;
+                var arrayString = Regex.Match(type.Name, @"[\[,\]]*&?$").Value;
                 typeName = typeName.Substring(0, typeName.Length - arrayString.Length);
 
                 var paramString = string.Join(",",

--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -179,7 +179,7 @@ namespace LoxSmoke.DocXml
             {
                 var typeName = Regex.Replace(type.Name, "`[0-9]+", "");
 
-                var arrayString = Regex.Match(type.Name, @"([\[,\]]*)&?$").Captures.OfType<Capture>().SingleOrDefault()?.Value;
+                var arrayString = Regex.Match(type.Name, @"[\[,\]]*&?$").Captures.OfType<Capture>().SingleOrDefault()?.Value;
                 typeName = typeName.Substring(0, typeName.Length - arrayString.Length);
 
                 var paramString = string.Join(",",

--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -178,7 +178,7 @@ namespace LoxSmoke.DocXml
             if (type.MemberType == MemberTypes.TypeInfo && (type.IsGenericType || args.Length > 0) && (!type.IsClass || isMethodParameter))
             {
                 var paramString = string.Join(",",
-                    args.Select(o => GetTypeXmlId(o, false, isMethodParameter)).ToArray());
+                    args.Select(o => GetTypeXmlId(o, false, isMethodParameter)));
                 var typeName = Regex.Replace(type.Name, "`[0-9]+", "{" + paramString + "}");
                 fullTypeName = $"{typeNamespace}{typeName}{outString}";
             }
@@ -198,9 +198,9 @@ namespace LoxSmoke.DocXml
             {
                 var index = fullTypeName.IndexOf("[,");
                 var lastIndex = fullTypeName.IndexOf(']', index);
-                fullTypeName = fullTypeName.Replace(
-                    fullTypeName.Substring(index, lastIndex - index + 1),
-                    "[" + new string('x', lastIndex - index - 1).Replace("x", "0:,") + "0:]");
+                fullTypeName = fullTypeName.Substring(0, index + 1) +
+                    string.Join(",", Enumerable.Repeat("0:", lastIndex - index)) + 
+                    fullTypeName.Substring(lastIndex);
             }
             return fullTypeName;
         }

--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -177,14 +177,10 @@ namespace LoxSmoke.DocXml
 
             if (type.MemberType == MemberTypes.TypeInfo && (type.IsGenericType || args.Length > 0) && (!type.IsClass || isMethodParameter))
             {
-                var typeName = Regex.Replace(type.Name, "`[0-9]+", "");
-
-                var arrayString = Regex.Match(type.Name, @"[\[,\]]*&?$").Value;
-                typeName = typeName.Substring(0, typeName.Length - arrayString.Length);
-
                 var paramString = string.Join(",",
                     args.Select(o => GetTypeXmlId(o, false, isMethodParameter)).ToArray());
-                fullTypeName = $"{typeNamespace}{typeName}{{{paramString}}}{arrayString}{outString}";
+                var typeName = Regex.Replace(type.Name, "`[0-9]+", "{" + paramString + "}");
+                fullTypeName = $"{typeNamespace}{typeName}{outString}";
             }
             else if (type.IsNested)
             {

--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -178,9 +178,13 @@ namespace LoxSmoke.DocXml
             if (type.MemberType == MemberTypes.TypeInfo && (type.IsGenericType || args.Length > 0) && (!type.IsClass || isMethodParameter))
             {
                 var typeName = Regex.Replace(type.Name, "`[0-9]+", "");
+
+                var arrayString = Regex.Match(type.Name, @"([\[,\]]*)&?$").Captures.OfType<Capture>().SingleOrDefault()?.Value;
+                typeName = typeName.Substring(0, typeName.Length - arrayString.Length);
+
                 var paramString = string.Join(",",
                     args.Select(o => GetTypeXmlId(o, false, isMethodParameter)).ToArray());
-                fullTypeName = $"{typeNamespace}{typeName}{{{paramString}}}{outString}";
+                fullTypeName = $"{typeNamespace}{typeName}{{{paramString}}}{arrayString}{outString}";
             }
             else if (type.IsNested)
             {

--- a/test/DocXmlUnitTests/BaseTestClass.cs
+++ b/test/DocXmlUnitTests/BaseTestClass.cs
@@ -24,19 +24,19 @@ namespace DocXmlUnitTests
 
         public void AssertParam(MethodComments comments, int paramIndex, string name, string text)
         {
-            Assert.AreEqual(name, comments.Parameters[paramIndex].Item1);
-            Assert.AreEqual(text, comments.Parameters[paramIndex].Item2);
+            Assert.AreEqual(name, comments.Parameters[paramIndex].Name);
+            Assert.AreEqual(text, comments.Parameters[paramIndex].Text);
         }
         public void AssertParam(TypeComments comments, int paramIndex, string name, string text)
         {
-            Assert.AreEqual(name, comments.Parameters[paramIndex].Item1);
-            Assert.AreEqual(text, comments.Parameters[paramIndex].Item2);
+            Assert.AreEqual(name, comments.Parameters[paramIndex].Name);
+            Assert.AreEqual(text, comments.Parameters[paramIndex].Text);
         }
 
         public void AssertTypeParam(MethodComments comments, int paramIndex, string name, string text)
         {
-            Assert.AreEqual(name, comments.TypeParameters[paramIndex].Item1);
-            Assert.AreEqual(text, comments.TypeParameters[paramIndex].Item2);
+            Assert.AreEqual(name, comments.TypeParameters[paramIndex].Name);
+            Assert.AreEqual(text, comments.TypeParameters[paramIndex].Text);
         }
 
     }

--- a/test/DocXmlUnitTests/MethodCommentsUnitTests.cs
+++ b/test/DocXmlUnitTests/MethodCommentsUnitTests.cs
@@ -68,7 +68,7 @@ namespace DocXmlUnitTests
         {
             var constr = MyClass_Type.GetConstructor(Array.Empty<Type>());
             var mm = Reader.GetMethodComments(constr);
-            Assert.AreEqual(mm.Parameters.Count, 0);
+            Assert.AreEqual(0, mm.Parameters.Count);
             Assert.AreEqual("Constructor with no parameters", mm.Summary);
         }
 
@@ -126,7 +126,7 @@ namespace DocXmlUnitTests
         }
 
         [TestMethod]
-        public void MemberFunctio_ArrayParams_Comments()
+        public void MemberFunction_ArrayParams_Comments()
         {
             var mm = Reader.GetMethodComments(MyClass_MemberFunctionWithArray);
 

--- a/test/DocXmlUnitTests/MethodCommentsUnitTests.cs
+++ b/test/DocXmlUnitTests/MethodCommentsUnitTests.cs
@@ -63,27 +63,22 @@ namespace DocXmlUnitTests
             MySubClass_MultilineSummary = typeof(MySubClass).GetMethod(nameof(MySubClass.MultilineSummary));
         }
 
+        [TestMethod]
+        public void Constructor_Comments_NoParams()
+        {
+            var constr = MyClass_Type.GetConstructor(Array.Empty<Type>());
+            var mm = Reader.GetMethodComments(constr);
+            Assert.AreEqual(mm.Parameters.Count, 0);
+            Assert.AreEqual("Constructor with no parameters", mm.Summary);
+        }
 
         [TestMethod]
-        public void Constructor_Comments()
+        public void Constructor_Comments_OneParam()
         {
-            var constructors = MyClass_Type.GetConstructors();
-            Assert.AreEqual(2, constructors.Length);
-            foreach (var constr in constructors)
-            {
-                var mm = Reader.GetMethodComments(constr);
-                if (constr.GetParameters().Length == 0)
-                {
-                    Assert.AreEqual(mm.Parameters.Count, constr.GetParameters().Length);
-                    Assert.AreEqual("Constructor with no parameters", mm.Summary);
-                }
-                else if (constr.GetParameters().Length == 1)
-                {
-                    Assert.AreEqual(mm.Parameters.Count, constr.GetParameters().Length);
-                    AssertParam(mm, 0, "one", "Parameter one");
-                    Assert.AreEqual("Constructor with one parameter", mm.Summary);
-                }
-            }
+            var constr = MyClass_Type.GetConstructor(new[] { typeof(int) });
+            var mm = Reader.GetMethodComments(constr);
+            AssertParam(mm, 0, "one", "Parameter one");
+            Assert.AreEqual("Constructor with one parameter", mm.Summary);
         }
 
         [TestMethod]
@@ -255,26 +250,30 @@ namespace DocXmlUnitTests
         }
 
         [TestMethod]
-        public void MemberFunction_GenericTypeArray() {
-            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericTypeArray)));
+        public void MemberFunction_GenericTypeArray()
+        {
+            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericArray)));
             Assert.AreEqual("MemberFunctionWithGenericTypeArray description", comments.Summary);
         }
 
         [TestMethod]
-        public void MemberFunction_GenericTypeMultiDimArray() {
-            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericTypeMultiDimArray)));
+        public void MemberFunction_GenericTypeMultiDimArray()
+        {
+            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericMultiDimArray)));
             Assert.AreEqual("MemberFunctionWithGenericTypeMultiDimArray description", comments.Summary);
         }
 
         [TestMethod]
-        public void MemberFunction_GenericTypeJaggedArray() {
-            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericTypeJaggedArray)));
+        public void MemberFunction_GenericTypeJaggedArray()
+        {
+            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericJaggedArray)));
             Assert.AreEqual("MemberFunctionWithGenericTypeJaggedArray description", comments.Summary);
         }
 
         [TestMethod]
-        public void MemberFunction_GenericTypeOutArray() {
-            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericTypeOutArray)));
+        public void MemberFunction_GenericTypeOutArray()
+        {
+            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericOutArray)));
             Assert.AreEqual("MemberFunctionWithGenericTypeOutArray description", comments.Summary);
         }
 

--- a/test/DocXmlUnitTests/MethodCommentsUnitTests.cs
+++ b/test/DocXmlUnitTests/MethodCommentsUnitTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Xml.XPath;
 using DocXmlOtherLibForUnitTests;
 using DocXmlUnitTests.TestData;
 using LoxSmoke.DocXml;
@@ -253,6 +252,30 @@ namespace DocXmlUnitTests
         {
             var comments = Reader.GetMethodComments(MySubClass_MultilineSummary);
             Assert.AreEqual("Summary line 1\r\nSummary line 2\r\nSummary line 3", comments.Summary);
+        }
+
+        [TestMethod]
+        public void MemberFunction_GenericTypeArray() {
+            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericTypeArray)));
+            Assert.AreEqual("MemberFunctionWithGenericTypeArray description", comments.Summary);
+        }
+
+        [TestMethod]
+        public void MemberFunction_GenericTypeMultiDimArray() {
+            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericTypeMultiDimArray)));
+            Assert.AreEqual("MemberFunctionWithGenericTypeMultiDimArray description", comments.Summary);
+        }
+
+        [TestMethod]
+        public void MemberFunction_GenericTypeJaggedArray() {
+            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericTypeJaggedArray)));
+            Assert.AreEqual("MemberFunctionWithGenericTypeJaggedArray description", comments.Summary);
+        }
+
+        [TestMethod]
+        public void MemberFunction_GenericTypeOutArray() {
+            var comments = Reader.GetMethodComments(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericTypeOutArray)));
+            Assert.AreEqual("MemberFunctionWithGenericTypeOutArray description", comments.Summary);
         }
 
         [TestMethod]

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -304,6 +304,7 @@ namespace DocXmlUnitTests
         /// </summary>
         public class NestedClass
         {
+            public int Item { set { _ = value; } }
         }
     }
 }

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -82,6 +82,24 @@ namespace DocXmlUnitTests
         public MyClass(int one) { }
 
         /// <summary>
+        /// Constructor with one generic parameter
+        /// </summary>
+        /// <param name="one">Parameter one</param>
+        public MyClass(List<int> one) { }
+
+        /// <summary>
+        /// Constructor with one array parameter of generic type
+        /// </summary>
+        /// <param name="one">Parameter one</param>
+        public MyClass(List<int>[] one) { }
+
+        /// <summary>
+        /// Constructor with one array in parameter of generic type
+        /// </summary>
+        /// <param name="one">Parameter one</param>
+        public MyClass(in List<int>[] one) { }
+
+        /// <summary>
         /// Member function description
         /// </summary>
         /// <returns>Return value description</returns>
@@ -116,23 +134,23 @@ namespace DocXmlUnitTests
         /// MemberFunctionWithGenericTypeArray description
         /// </summary>
         /// <param name="arrayOfListOfInt">Parameter arrayOfListOfInt</param>
-        public static void MemberFunctionWithGenericTypeArray(params List<int>[] arrayOfListOfInt) { }
+        public static void MemberFunctionWithGenericArray(params List<int>[] arrayOfListOfInt) { }
 
         /// <summary>
         /// MemberFunctionWithGenericTypeMultiDimArray description
         /// </summary>
         /// <param name="multiDimArrayOfListOfInt">Parameter multiDimArrayOfListOfInt</param>
-        public static void MemberFunctionWithGenericTypeMultiDimArray(List<int>[,] multiDimArrayOfListOfInt) { }
+        public static void MemberFunctionWithGenericMultiDimArray(List<int>[,] multiDimArrayOfListOfInt) { }
 
         /// <summary>
         /// MemberFunctionWithGenericTypeJaggedArray description
         /// </summary>
         /// <param name="jaggedArrayOfListOfInt">Parameter jaggedArrayOfListOfInt</param>
-        public static void MemberFunctionWithGenericTypeJaggedArray(List<int>[][] jaggedArrayOfListOfInt) { }
+        public static void MemberFunctionWithGenericJaggedArray(List<int>[][] jaggedArrayOfListOfInt) { }
 
         /// <summary>MemberFunctionWithGenericTypeOutArray description</summary>
         /// <param name="outArrayOfListOfInt">Parameter outArrayOfListOfInt</param>
-        public static void MemberFunctionWithGenericTypeOutArray(out List<float>[] outArrayOfListOfInt)
+        public static void MemberFunctionWithGenericOutArray(out List<float>[] outArrayOfListOfInt)
             => outArrayOfListOfInt = new[] { new List<float>() };
 
         /// <summary>
@@ -165,6 +183,58 @@ namespace DocXmlUnitTests
         {
             get { return 1; }
             set { }
+        }
+
+        /// <summary>
+        /// ItemPropertyTwoParams description
+        /// </summary>
+        /// <param name="parameter1">Parameter1 description</param>
+        /// <param name="parameter2">Parameter2 description</param>
+        /// <returns>Return value description</returns>
+        public int this[int parameter1, string parameter2]
+        {
+            get { return 1; }
+            set { }
+        }
+
+        /// <summary>
+        /// ItemPropertyInParam description
+        /// </summary>
+        /// <param name="parameter">Parameter description</param>
+        /// <returns>Return value description</returns>
+        public int this[in int parameter]
+        {
+            get { return 1; }
+        }
+
+        /// <summary>
+        /// ItemPropertyGenericParam description
+        /// </summary>
+        /// <param name="parameter">Parameter description</param>
+        /// <returns>Return value description</returns>
+        public int this[List<int> parameter]
+        {
+            get { return 1; }
+        }
+
+        /// <summary>
+        /// ItemPropertyGenericArrayParam description
+        /// </summary>
+        /// <param name="parameter">Parameter description</param>
+        /// <returns>Return value description</returns>
+        public int this[List<int>[] parameter]
+        {
+            get { return 1; }
+        }
+
+        /// <summary>
+        /// ItemPropertyGenericMultiDimArrayInParam description
+        /// </summary>
+        /// <param name="parameter">Parameter description</param>
+        /// <returns>Return value description</returns>
+        public int this[in List<int>[,,] parameter]
+        {
+            get { return 1; }
         }
 
         /// <summary>
@@ -204,6 +274,17 @@ namespace DocXmlUnitTests
         /// <param name="parameter2">Parameter description</param>
         /// <returns>Return value description</returns>
         public List<X> TemplateMethod3<X,Y>(List<X> parameter1, List<Y> parameter2)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// TemplateMethod4 description
+        /// </summary>
+        /// <typeparam name="T">Type parameter</typeparam>
+        /// <param name="parameter">Parameter description</param>
+        /// <returns>Return value description</returns>
+        public List<T> TemplateMethod4<T>(in List<T>[][][] parameter)
         {
             return null;
         }

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace DocXmlUnitTests
 {

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace DocXmlUnitTests
@@ -112,6 +113,29 @@ namespace DocXmlUnitTests
         /// <param name="array2">Parameter array2</param>
         /// <returns>Return value description</returns>
         public int MemberFunctionWithArray(short[] array1, int[,] array2) { return 0; }
+
+        /// <summary>
+        /// MemberFunctionWithGenericTypeArray description
+        /// </summary>
+        /// <param name="arrayOfListOfInt">Parameter arrayOfListOfInt</param>
+        public static void MemberFunctionWithGenericTypeArray(params List<int>[] arrayOfListOfInt) { }
+
+        /// <summary>
+        /// MemberFunctionWithGenericTypeMultiDimArray description
+        /// </summary>
+        /// <param name="multiDimArrayOfListOfInt">Parameter multiDimArrayOfListOfInt</param>
+        public static void MemberFunctionWithGenericTypeMultiDimArray(List<int>[,] multiDimArrayOfListOfInt) { }
+
+        /// <summary>
+        /// MemberFunctionWithGenericTypeJaggedArray description
+        /// </summary>
+        /// <param name="jaggedArrayOfListOfInt">Parameter jaggedArrayOfListOfInt</param>
+        public static void MemberFunctionWithGenericTypeJaggedArray(List<int>[][] jaggedArrayOfListOfInt) { }
+
+        /// <summary>MemberFunctionWithGenericTypeOutArray description</summary>
+        /// <param name="outArrayOfListOfInt">Parameter outArrayOfListOfInt</param>
+        public static void MemberFunctionWithGenericTypeOutArray(out List<float>[] outArrayOfListOfInt)
+            => outArrayOfListOfInt = new[] { new List<float>() };
 
         /// <summary>
         /// Delegate type description

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -172,7 +172,7 @@ namespace DocXmlUnitTests
         /// </summary>
         /// <param name="parameter">Parameter description</param>
         /// <returns>Return value description</returns>
-        public int this[string parameter] { get { return 1; } }
+        public int this[string parameter] => 1;
 
         /// <summary>
         /// ItemGetSetProperty description
@@ -181,7 +181,7 @@ namespace DocXmlUnitTests
         /// <returns>Return value description</returns>
         public int this[int parameter]
         {
-            get { return 1; }
+            get => 1;
             set { }
         }
 
@@ -193,7 +193,7 @@ namespace DocXmlUnitTests
         /// <returns>Return value description</returns>
         public int this[int parameter1, string parameter2]
         {
-            get { return 1; }
+            get => 1;
             set { }
         }
 
@@ -202,57 +202,42 @@ namespace DocXmlUnitTests
         /// </summary>
         /// <param name="parameter">Parameter description</param>
         /// <returns>Return value description</returns>
-        public int this[in int parameter]
-        {
-            get { return 1; }
-        }
+        public int this[in int parameter]  => 1;
 
         /// <summary>
         /// ItemPropertyGenericParam description
         /// </summary>
         /// <param name="parameter">Parameter description</param>
         /// <returns>Return value description</returns>
-        public int this[List<int> parameter]
-        {
-            get { return 1; }
-        }
+        public int this[List<int> parameter] => 1;
 
         /// <summary>
         /// ItemPropertyGenericArrayParam description
         /// </summary>
         /// <param name="parameter">Parameter description</param>
         /// <returns>Return value description</returns>
-        public int this[List<int>[] parameter]
-        {
-            get { return 1; }
-        }
+        public int this[List<int>[] parameter] => 1;
 
         /// <summary>
         /// ItemPropertyGenericMultiDimArrayInParam description
         /// </summary>
         /// <param name="parameter">Parameter description</param>
         /// <returns>Return value description</returns>
-        public int this[in List<int>[,,] parameter]
-        {
-            get { return 1; }
-        }
+        public int this[in List<int>[,,] parameter] => 1;
 
         /// <summary>
         /// Operator description
         /// </summary>
         /// <param name="parameter">Parameter description</param>
         /// <returns>Return value description</returns>
-        public static explicit operator int(MyClass parameter) { return 1; }
+        public static explicit operator int(MyClass parameter) => 1;
 
         /// <summary>
         /// TemplateMethod description
         /// </summary>
         /// <typeparam name="T">Type parameter</typeparam>
         /// <returns>Return value description</returns>
-        public List<T> TemplateMethod<T>()
-        {
-            return null;
-        }
+        public List<T> TemplateMethod<T>() => null;
 
         /// <summary>
         /// TemplateMethod2 description
@@ -260,10 +245,7 @@ namespace DocXmlUnitTests
         /// <typeparam name="T">Type parameter</typeparam>
         /// <param name="parameter">Parameter description</param>
         /// <returns>Return value description</returns>
-        public List<T> TemplateMethod2<T>(List<T> parameter)
-        {
-            return null;
-        }
+        public List<T> TemplateMethod2<T>(List<T> parameter) => null;
 
         /// <summary>
         /// TemplateMethod3 description
@@ -273,10 +255,7 @@ namespace DocXmlUnitTests
         /// <param name="parameter1">Parameter description</param>
         /// <param name="parameter2">Parameter description</param>
         /// <returns>Return value description</returns>
-        public List<X> TemplateMethod3<X,Y>(List<X> parameter1, List<Y> parameter2)
-        {
-            return null;
-        }
+        public List<X> TemplateMethod3<X, Y>(List<X> parameter1, List<Y> parameter2) => null;
 
         /// <summary>
         /// TemplateMethod4 description

--- a/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
+++ b/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
@@ -218,6 +218,13 @@ namespace DocXmlUnitTests
         }
 
         [TestMethod]
+        public void XmlDocId_MemberId_ItemSetOnlyProperty() {
+            var info = typeof(MyClass.NestedClass).GetMember(nameof(MyClass.NestedClass.Item)).First();
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.NestedClass.Item", id);
+        }
+
+        [TestMethod]
         public void XmlDocId_MemberId_Indexer()
         {
             var info = typeof(MyClass).GetProperty("Item", new[] { typeof(string) });

--- a/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
+++ b/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
@@ -218,7 +218,8 @@ namespace DocXmlUnitTests
         }
 
         [TestMethod]
-        public void XmlDocId_MemberId_ItemSetOnlyProperty() {
+        public void XmlDocId_MemberId_ItemSetOnlyProperty()
+        {
             var info = typeof(MyClass.NestedClass).GetMember(nameof(MyClass.NestedClass.Item)).First();
             var id = info.MemberId();
             Assert.AreEqual("P:DocXmlUnitTests.MyClass.NestedClass.Item", id);

--- a/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
+++ b/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
@@ -84,9 +84,41 @@ namespace DocXmlUnitTests
         [TestMethod]
         public void XmlDocId_MemberId_Constructor()
         {
-            var info = typeof(MyClass).GetConstructors().First();
+            var info = typeof(MyClass).GetConstructor(Array.Empty<Type>());
             var id = info.MemberId();
             Assert.AreEqual("M:DocXmlUnitTests.MyClass.#ctor", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_ConstructorWithParam()
+        {
+            var info = typeof(MyClass).GetConstructor(new[] { typeof(int) });
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.#ctor(System.Int32)", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_ConstructorWithGenericParam()
+        {
+            var info = typeof(MyClass).GetConstructor(new[] { typeof(List<int>) });
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.#ctor(System.Collections.Generic.List{System.Int32})", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_ConstructorWithGenericArrayParam()
+        {
+            var info = typeof(MyClass).GetConstructor(new[] { typeof(List<int>[]) });
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.#ctor(System.Collections.Generic.List{System.Int32}[])", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_ConstructorWithGenericArrayInParam()
+        {
+            var info = typeof(MyClass).GetConstructor(new[] { typeof(List<int>[]).MakeByRefType() });
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.#ctor(System.Collections.Generic.List{System.Int32}[]@)", id);
         }
 
         [TestMethod]
@@ -98,11 +130,139 @@ namespace DocXmlUnitTests
         }
 
         [TestMethod]
+        public void XmlDocId_MemberId_MethodWithRefParam()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.MemberFunction2), new[] { typeof(int), typeof(int).MakeByRefType() });
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.MemberFunction2(System.Int32,System.Int32@)", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_MethodWithArrayParam()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithArray));
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.MemberFunctionWithArray(System.Int16[],System.Int32[0:,0:])", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_MethodWithGenericArrayParam()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericArray));
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.MemberFunctionWithGenericArray(System.Collections.Generic.List{System.Int32}[])", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_MethodWithGenericMultiDimArrayParam()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericMultiDimArray));
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.MemberFunctionWithGenericMultiDimArray(System.Collections.Generic.List{System.Int32}[0:,0:])", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_MethodWithGenericJaggedArrayParam()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericJaggedArray));
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.MemberFunctionWithGenericJaggedArray(System.Collections.Generic.List{System.Int32}[][])", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_MethodWithGenericJaggedArrayOutParam()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithGenericOutArray));
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.MemberFunctionWithGenericOutArray(System.Collections.Generic.List{System.Single}[]@)", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateMethod()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.TemplateMethod));
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.TemplateMethod``1", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateMethodWithGenericParam()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.TemplateMethod2));
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.TemplateMethod2``1(System.Collections.Generic.List{``0})", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateMethodWithTwoTemplateTypes()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.TemplateMethod3));
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.TemplateMethod3``2(System.Collections.Generic.List{``0},System.Collections.Generic.List{``1})", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateMethodWithGenericJaggedArrayInParam()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.TemplateMethod4));
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.TemplateMethod4``1(System.Collections.Generic.List{``0}[][][]@)", id);
+        }
+
+        [TestMethod]
         public void XmlDocId_MemberId_Property()
         {
             var info = typeof(MyClass).GetMember(nameof(MyClass.GetSetProperty)).First();
             var id = info.MemberId();
             Assert.AreEqual("P:DocXmlUnitTests.MyClass.GetSetProperty", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_Indexer()
+        {
+            var info = typeof(MyClass).GetProperty("Item", new[] { typeof(string) });
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.Item(System.String)", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_IndexerWithTwoParams()
+        {
+            var info = typeof(MyClass).GetProperty("Item", new[] { typeof(int), typeof(string) });
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.Item(System.Int32,System.String)", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_IndexerWithInParam()
+        {
+            var info = typeof(MyClass).GetProperty("Item", new[] { typeof(int).MakeByRefType() });
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.Item(System.Int32@)", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_IndexerWithGenericParam()
+        {
+            var info = typeof(MyClass).GetProperty("Item", new[] { typeof(List<int>) });
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.Item(System.Collections.Generic.List{System.Int32})", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_IndexerWithGenericArrayParam()
+        {
+            var info = typeof(MyClass).GetProperty("Item", new[] { typeof(List<int>[]) });
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.Item(System.Collections.Generic.List{System.Int32}[])", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_IndexerWithGenericMultiDimArrayInParam()
+        {
+            var info = typeof(MyClass).GetProperty("Item", new[] { typeof(List<int>[,,]).MakeByRefType() });
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.Item(System.Collections.Generic.List{System.Int32}[0:,0:,0:]@)", id);
         }
 
         [TestMethod]
@@ -120,6 +280,7 @@ namespace DocXmlUnitTests
             var id = info.MemberId();
             Assert.AreEqual("T:DocXmlUnitTests.MyClass.NestedClass", id);
         }
+
         [TestMethod]
         public void XmlDocId_MemberId_Event()
         {
@@ -127,6 +288,7 @@ namespace DocXmlUnitTests
             var id = info.MemberId();
             Assert.AreEqual("E:DocXmlUnitTests.MyClass.eventField", id);
         }
+
         [TestMethod]
         public void XmlDocId_MemberId_Unsupported()
         {


### PR DESCRIPTION
Fixes a problem with the generation of XML IDs for arrays of generic types. For instance, a method parameter of type `List<int>[]` will have the following XML ID in the XML documentation:

```
System.Collections.Generic.List{System.Int32}[]
```

 DocXml however generates an incorrenct XML ID from the reflection data:

```
System.Collections.Generic.List[]{System.Int32}
```

As you can see the array brackets are in the wrong place and thus no documentation can be retrieved for this method.