### PR TITLE
In out ref parameters

### DIFF
--- a/src/DocXml/Reflection/ReflectionExtensions.cs
+++ b/src/DocXml/Reflection/ReflectionExtensions.cs
@@ -147,7 +147,7 @@ namespace DocXml.Reflection
         {
             if (parameterInfo.ParameterType.IsByRef)
             {
-                return (parameterInfo.ParameterType.IsByRef ? (parameterInfo.IsIn ? "in " : (parameterInfo.IsOut ? "out " : "ref ")) : "") +
+                return (parameterInfo.IsIn ? "in " : (parameterInfo.IsOut ? "out " : "ref ")) +
                     parameterInfo.ParameterType.GetElementType().ToNameStringWithValueTupleNames(
                     parameterInfo.GetCustomAttribute<TupleElementNamesAttribute>()?.TransformNames, typeNameConverter,
                     invokeTypeNameConverterForGenericType);

--- a/src/DocXml/Reflection/ReflectionExtensions.cs
+++ b/src/DocXml/Reflection/ReflectionExtensions.cs
@@ -122,7 +122,7 @@ namespace DocXml.Reflection
         {
             var parameters = methodInfo.GetParameters();
             if (parameters.Length == 0) return "()";
-            return "(" + string.Join(", ", parameters.Select(s => s.ToTypeNameString(typeNameConverter, invokeTypeNameConverterForGenericType) + " " + s.Name)) + ")";
+            return "(" + string.Join(", ", parameters.Select(p => p.ToTypeNameString(typeNameConverter, invokeTypeNameConverterForGenericType) + " " + p.Name)) + ")";
         }
 
         /// <summary>
@@ -145,7 +145,15 @@ namespace DocXml.Reflection
         public static string ToTypeNameString(this ParameterInfo parameterInfo, Func<Type, Queue<string>, string> typeNameConverter = null,
             bool invokeTypeNameConverterForGenericType = false)
         {
-            return parameterInfo.ParameterType.ToNameStringWithValueTupleNames(
+            if (parameterInfo.ParameterType.IsByRef)
+            {
+                return (parameterInfo.ParameterType.IsByRef ? (parameterInfo.IsIn ? "in " : (parameterInfo.IsOut ? "out " : "ref ")) : "") +
+                    parameterInfo.ParameterType.GetElementType().ToNameStringWithValueTupleNames(
+                    parameterInfo.GetCustomAttribute<TupleElementNamesAttribute>()?.TransformNames, typeNameConverter,
+                    invokeTypeNameConverterForGenericType);
+            }
+            return
+                parameterInfo.ParameterType.ToNameStringWithValueTupleNames(
                 parameterInfo.GetCustomAttribute<TupleElementNamesAttribute>()?.TransformNames, typeNameConverter,
                 invokeTypeNameConverterForGenericType);
         }
@@ -273,6 +281,12 @@ namespace DocXml.Reflection
         public static string ToNameString(this Type type, Queue<string> tupleFieldNames, Func<Type, Queue<string>, string> typeNameConverter = null, 
             bool invokeTypeNameConverterForGenericType = false)
         {
+            if (type.IsByRef)
+            {
+                return  "ref " + 
+                    type.GetElementType().ToNameString(tupleFieldNames, typeNameConverter, invokeTypeNameConverterForGenericType);
+            }
+
             var decoratedTypeName = type.IsGenericType ? null : typeNameConverter?.Invoke(type, tupleFieldNames);
 
             if (decoratedTypeName != null &&

--- a/test/DocXmlUnitTests/ReflectionExtensionsUnitTests.cs
+++ b/test/DocXmlUnitTests/ReflectionExtensionsUnitTests.cs
@@ -48,6 +48,30 @@ namespace DocXmlUnitTests
         }
 
         [DataTestMethod]
+        [DataRow(typeof(DateTime), "ref DateTime")]
+        [DataRow(typeof(double), "ref double")]
+        [DataRow(typeof(char), "ref char")]
+        [DataRow(typeof(int), "ref int")]
+        [DataRow(typeof(bool), "ref bool")]
+        [DataRow(typeof(void), "ref void")]
+        [DataRow(typeof(string), "ref string")]
+
+        [DataRow(typeof(bool?), "ref bool?")]
+        [DataRow(typeof(List<bool?>), "ref List<bool?>")]
+        [DataRow(typeof(List<>), "ref List<T>")]
+        [DataRow(typeof(bool[]), "ref bool[]")]
+        [DataRow(typeof(bool[,]), "ref bool[,]")]
+        [DataRow(typeof(bool[,,]), "ref bool[,,]")]
+        public void ToNameString_RefType(Type type, string expectedText)
+        {
+            var text = type.MakeByRefType().ToNameString();
+            Assert.AreEqual(expectedText, text);
+
+            var text2 = type.MakeByRefType().ToNameString((_, queue) => null);
+            Assert.AreEqual(expectedText, text2);
+        }
+
+        [DataTestMethod]
         [DataRow(typeof(List<>), true, "*List*<+T+>")]
         [DataRow(typeof(List<>), false, "List<+T+>")]
         [DataRow(typeof(List<int>), true, "*List*<*int*>")]
@@ -78,9 +102,16 @@ namespace DocXmlUnitTests
 
         [DataTestMethod]
         [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.PublicMethod), "()")]
+        [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.MethodWithRefParam), "(ref int refParam)")]
+        [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.MethodWithOutParam), "(out int outParam)")]
+        [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.MethodWithInParam), "(in int inParam)")]
+        [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.MethodWithNullableParam), "(int? nullableParam)")]
+        [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.MethodWithNullableInParam), "(in int? nullableInParam)")]
         [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.GetTuple1), "()")]
         [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.GetTuple2), "((string Three, string Four) tupleParam)")]
+        [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.GetTuple2Ref), "(ref (string Three, string Four) tupleParam)")]
         [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.GetTuple3), "((string, string) unnamedTupleParam)")]
+        [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.GetTuple3Ref), "(ref (string, string) unnamedTupleParam)")]
         [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.GetTuple4), "((string, string) unnamedTupleParam, (string Three, string Four) tupleParam)")]
         [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.GetTuple5), "((string A1, string A2, string A3, string A4, string A5, string A6, string A7) tupleParam)")]
         [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.GetTuple6), "((string A1, string A2, string A3, string A4, string A5, string A6, (string A8, string A9)) tupleParam)")]
@@ -95,6 +126,7 @@ namespace DocXmlUnitTests
         [DataTestMethod]
         [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.PublicMethod), "void")]
         [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.GetTuple1), "(string One, string Two)")]
+        [DataRow(typeof(MethodsReflectionClass), nameof(MethodsReflectionClass.MethodWithRefReturn), "ref int")]
         public void ToTypeNameString_MethodReturn(Type type, string methodName, string expectedText)
         {
             var methodInfo = type.GetMethod(methodName);
@@ -105,6 +137,7 @@ namespace DocXmlUnitTests
         [DataTestMethod]
         [DataRow(typeof(TCTestPropertyClass), nameof(TCTestPropertyClass.DoubleListProperty), "List<double>")]
         [DataRow(typeof(TCTestPropertyClass), nameof(TCTestPropertyClass.TupleProperty), "(int One, int Two)")]
+        [DataRow(typeof(TCTestPropertyClass), nameof(TCTestPropertyClass.RefProperty), "ref int")]
         public void ToTypeNameString_Property(Type type, string propName, string expectedText)
         {
             var propInfo = type.GetProperty(propName);

--- a/test/DocXmlUnitTests/TestData.Reflection.TypeCollection/TCTestPropertyClass.cs
+++ b/test/DocXmlUnitTests/TestData.Reflection.TypeCollection/TCTestPropertyClass.cs
@@ -64,5 +64,11 @@ namespace DocXmlUnitTests.TestData.Reflection
         /// TupleProperty
         /// </summary>
         public (int One, int Two) TupleProperty { get; set; }
+
+        /// <summary>
+        /// RefProperty
+        /// </summary>
+        public ref int RefProperty => ref fieldForRef;
+        private int fieldForRef;
     }
 }

--- a/test/DocXmlUnitTests/TestData.Reflection/MethodsReflectionClass.cs
+++ b/test/DocXmlUnitTests/TestData.Reflection/MethodsReflectionClass.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace DocXmlUnitTests.TestData.Reflection
+﻿namespace DocXmlUnitTests.TestData.Reflection
 {
     /// <summary>
     /// Test data class with methods
@@ -45,6 +41,36 @@ namespace DocXmlUnitTests.TestData.Reflection
         }
 
         /// <summary>
+        /// MethodWithRefReturn
+        /// </summary>
+        public ref int MethodWithRefReturn(ref int x) => ref x;
+
+        /// <summary>
+        /// MethodWithRefParam
+        /// </summary>
+        public void MethodWithRefParam(ref int refParam) { }
+
+        /// <summary>
+        /// MethodWithOutParam
+        /// </summary>
+        public void MethodWithOutParam(out int outParam) { outParam = 0; }
+
+        /// <summary>
+        /// MethodWithInParam
+        /// </summary>
+        public void MethodWithInParam(in int inParam) { }
+
+        /// <summary>
+        /// MethodWithNullableParam
+        /// </summary>
+        public void MethodWithNullableParam(int? nullableParam) { }
+
+        /// <summary>
+        /// MethodWithNullableInParam
+        /// </summary>
+        public void MethodWithNullableInParam(in int? nullableInParam) { }
+
+        /// <summary>
         /// Return one tuple
         /// </summary>
         /// <returns></returns>
@@ -63,10 +89,28 @@ namespace DocXmlUnitTests.TestData.Reflection
         }
 
         /// <summary>
+        /// Return one tuple and ref param tuple
+        /// </summary>
+        /// <returns></returns>
+        public (string One, string Two) GetTuple2Ref(ref (string Three, string Four) tupleParam)
+        {
+            return ("", "");
+        }
+
+        /// <summary>
         /// Return one tuple and unnamed param tuple
         /// </summary>
         /// <returns></returns>
         public (string One, string Two) GetTuple3((string, string) unnamedTupleParam)
+        {
+            return ("", "");
+        }
+
+        /// <summary>
+        /// Return one tuple and unnamed ref param tuple
+        /// </summary>
+        /// <returns></returns>
+        public (string One, string Two) GetTuple3Ref(ref (string, string) unnamedTupleParam)
         {
             return ("", "");
         }


### PR DESCRIPTION
Reworked code from pull request #5 
ToTypeNameString() function returns parameters with proper in, out or ref prefixes. 