### PR TITLE
Use `GetElementType()` on `in`, `out`, and `ref` types as well

### DIFF
--- a/src/DocXml/Reflection/TypeCollection.cs
+++ b/src/DocXml/Reflection/TypeCollection.cs
@@ -300,7 +300,7 @@ namespace LoxSmoke.DocXml.Reflection
                 }
                 return;
             }
-            else if (type.IsArray) // SomeType[]
+            else if (type.IsArray || type.IsByRef) // SomeType[] or ref SomeType
             {
                 UnwrapType(parentType, type.GetElementType());
             }

--- a/test/DocXmlUnitTests/TestData.Reflection.TypeCollection/TCTestClass.cs
+++ b/test/DocXmlUnitTests/TestData.Reflection.TypeCollection/TCTestClass.cs
@@ -40,5 +40,17 @@ namespace DocXmlUnitTests.TestData.Reflection
         /// ClassListProperty
         /// </summary>
         public List<TCTestListPropertyClass> ClassListProperty { get; set; }
+
+        /// <summary>
+        /// ClassMethod
+        /// </summary>
+        /// <param name="parameter">TCTestParameterClass parameter</param>
+        public void ClassMethod(TCTestParameterClass parameter) { }
+
+        /// <summary>
+        /// RefClassMethod
+        /// </summary>
+        /// <param name="parameter">TCTestParameterClass ref parameter</param>
+        public void RefClassMethod(ref TCTestParameterClass parameter) { }
     }
 }

--- a/test/DocXmlUnitTests/TestData.Reflection.TypeCollection/TCTestParameterClass.cs
+++ b/test/DocXmlUnitTests/TestData.Reflection.TypeCollection/TCTestParameterClass.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DocXmlUnitTests.TestData.Reflection
+{
+    /// <summary>
+    /// TCTestParameterClass
+    /// </summary>
+    public class TCTestParameterClass
+    {
+    }
+}

--- a/test/DocXmlUnitTests/TypeCollectionUnitTests.cs
+++ b/test/DocXmlUnitTests/TypeCollectionUnitTests.cs
@@ -48,12 +48,14 @@ namespace DocXmlUnitTests
 
             var tc = TypeCollection.ForReferencedTypes(typeof(TCTestClass), settings);
 
-            Assert.AreEqual(5, tc.ReferencedTypes.Count);
+            Assert.AreEqual(6, tc.ReferencedTypes.Count);
             Assert.IsTrue(tc.ReferencedTypes.ContainsKey(typeof(ReflectionTestEnum2)));
             Assert.IsTrue(tc.ReferencedTypes.ContainsKey(typeof(TCTestClass)));
             Assert.IsTrue(tc.ReferencedTypes.ContainsKey(typeof(TCTestPropertyClass)));
             Assert.IsTrue(tc.ReferencedTypes.ContainsKey(typeof(TCTestListPropertyClass)));
             Assert.IsTrue(tc.ReferencedTypes.ContainsKey(typeof(ReflectionTestEnum1)));
+            Assert.IsTrue(tc.ReferencedTypes.ContainsKey(typeof(TCTestParameterClass)));
+            Assert.IsFalse(tc.ReferencedTypes.ContainsKey(typeof(TCTestParameterClass).MakeByRefType()));
         }
 
         [TestMethod]


### PR DESCRIPTION
This fixes the problem if mentioned in pull request #7 where a reference of type `T` that has one of the modifiers `in`, `out`, or `ref`, causes `TypeCollection.ForReferencedTypes()` to return it as `typeof(T).MakeByRefType()` instead of `typeof(T)`. This in turn causes mddox to generate a type index with duplicated types containing e.g. `Config Struct` _and_ `ref Config Struct`.

By the way: I might have found another issue where mddox fails to retrieve the `<summary>` of my enum type _values_. But that I'll have to investigate some other time this week. Just saying that, because you might wanna hold off a release until that problem is fixed as well.