### PR TITLE
Fix empty enum comments when getting via assembly instead of type

### DIFF
--- a/src/DocXml/DocXmlReader.cs
+++ b/src/DocXml/DocXmlReader.cs
@@ -223,7 +223,7 @@ namespace LoxSmoke.DocXml
             if (!enumType.IsEnum) throw new ArgumentException(nameof(enumType));
 
             var comments = new EnumComments();
-            var typeNode = GetXmlMemberNode(enumType.TypeId(), enumType?.ReflectedType);
+            var typeNode = GetXmlMemberNode(enumType.TypeId(), enumType);
             if (typeNode != null)
             {
                 GetCommonComments(comments, typeNode);
@@ -232,7 +232,7 @@ namespace LoxSmoke.DocXml
             bool valueCommentsExist = false;
             foreach (var enumName in enumType.GetEnumNames())
             {
-                var valueNode = GetXmlMemberNode(enumType.EnumValueId(enumName), enumType?.ReflectedType);
+                var valueNode = GetXmlMemberNode(enumType.EnumValueId(enumName), enumType);
                 valueCommentsExist |= (valueNode != null);
                 var valueComment = new EnumValueComment()
                 {

--- a/test/DocXmlOtherLibForUnitTests/TestData/OtherEnum.cs
+++ b/test/DocXmlOtherLibForUnitTests/TestData/OtherEnum.cs
@@ -1,0 +1,12 @@
+﻿namespace DocXmlOtherLibForUnitTests.TestData {
+    /// <summary>
+    /// Other enum
+    /// </summary>
+    public enum OtherEnum
+    {
+        /// <summary>
+        /// Enum value one
+        /// </summary>
+        Value1 = 1
+    }
+}

--- a/test/DocXmlOtherLibForUnitTests/TestData/OtherEnum.cs
+++ b/test/DocXmlOtherLibForUnitTests/TestData/OtherEnum.cs
@@ -1,4 +1,5 @@
-﻿namespace DocXmlOtherLibForUnitTests.TestData {
+﻿namespace DocXmlOtherLibForUnitTests.TestData
+{
     /// <summary>
     /// Other enum
     /// </summary>

--- a/test/DocXmlUnitTests/EnumCommentsUnitTests.cs
+++ b/test/DocXmlUnitTests/EnumCommentsUnitTests.cs
@@ -2,9 +2,6 @@
 using LoxSmoke.DocXml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 
 #pragma warning disable CS1591
 
@@ -97,12 +94,7 @@ namespace DocXmlUnitTests
         [TestMethod]
         public void EnumType_WithValue_Comments_OtherAssembly()
         {
-            var docReader = new DocXmlReader(
-                new[] { typeof(MyClass).Assembly, typeof(OtherEnum).Assembly },
-                (a) => Path.GetFileNameWithoutExtension(a.Location) + ".xml");
-
-            var mm = docReader.GetEnumComments(typeof(OtherEnum));
-
+            var mm = new DocXmlReader().GetEnumComments(typeof(OtherEnum));
             Assert.AreEqual("Other enum", mm.Summary);
             Assert.AreEqual(1, mm.ValueComments.Count);
             AssertEnumComment(1, "Value1", "Enum value one", mm.ValueComments[0]);

--- a/test/DocXmlUnitTests/EnumCommentsUnitTests.cs
+++ b/test/DocXmlUnitTests/EnumCommentsUnitTests.cs
@@ -1,7 +1,9 @@
-﻿using LoxSmoke.DocXml;
+﻿using DocXmlOtherLibForUnitTests.TestData;
+using LoxSmoke.DocXml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 #pragma warning disable CS1591
@@ -92,5 +94,18 @@ namespace DocXmlUnitTests
             AssertEnumComment(20, "Value2", "Enum value two", mm.ValueComments[1]);
         }
 
+        [TestMethod]
+        public void EnumType_WithValue_Comments_OtherAssembly()
+        {
+            var docReader = new DocXmlReader(
+                new[] { typeof(MyClass).Assembly, typeof(OtherEnum).Assembly },
+                (a) => Path.GetFileNameWithoutExtension(a.Location) + ".xml");
+
+            var mm = docReader.GetEnumComments(typeof(OtherEnum));
+
+            Assert.AreEqual("Other enum", mm.Summary);
+            Assert.AreEqual(1, mm.ValueComments.Count);
+            AssertEnumComment(1, "Value1", "Enum value one", mm.ValueComments[0]);
+        }
     }
 }


### PR DESCRIPTION
This adds a test case that fails when trying to get enum comments via the assembly rather than a type.

I guess this is due to the `DocXmlReader.assemblyNavigators` not being properly initialized, but I haven't had enough time to look into it yet.

The `DocXmlReader` is quite stateful which makes the analysis and debugging a bit hard when you don't know the code. I could use your assistance here, please 😊 