### PR TITLE
Fix XML ID generation of set-only indexers

### DIFF
--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -113,7 +113,7 @@ namespace LoxSmoke.DocXml
                 {
                     return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." +
                            propertyInfo.Name +
-                           GetParametersXmlId(setParameters.Skip(1));
+                           GetParametersXmlId(setParameters.Take(setParameters.Length - 1), GetGenericClassParams(propertyInfo));
                 }
             }
             return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." + propertyInfo.Name;
@@ -199,7 +199,7 @@ namespace LoxSmoke.DocXml
                 var index = fullTypeName.IndexOf("[,");
                 var lastIndex = fullTypeName.IndexOf(']', index);
                 fullTypeName = fullTypeName.Substring(0, index + 1) +
-                    string.Join(",", Enumerable.Repeat("0:", lastIndex - index)) + 
+                    string.Join(",", Enumerable.Repeat("0:", lastIndex - index)) +
                     fullTypeName.Substring(lastIndex);
             }
             return fullTypeName;
@@ -247,7 +247,6 @@ namespace LoxSmoke.DocXml
                 (methodInfo.Name != "op_Explicit" && methodInfo.Name != "op_Implicit")) return "";
             return "~" + GetTypeXmlId((methodInfo as MethodInfo).ReturnType);
         }
-
 
         /// <summary>
         /// Get method name. Some methods have special names or like generic methods some extra information.

--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -113,7 +113,7 @@ namespace LoxSmoke.DocXml
                 {
                     return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." +
                            propertyInfo.Name +
-                           GetParametersXmlId(setParameters.Take(setParameters.Length - 1), GetGenericClassParams(propertyInfo));
+                           GetParametersXmlId(setParameters.Take(setParameters.Length - 1));
                 }
             }
             return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." + propertyInfo.Name;

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -285,6 +285,20 @@ namespace DocXmlUnitTests
         {
             public int Item { set { _ = value; } }
         }
+
+        /// <summary>Class having a get only indexer.</summary>
+        public class ClassWithGetOnlyIndexer
+        {
+            /// <summary>Indexer allowing only get.</summary>
+            public bool this[int i, string s] { get => true; }
+        }
+
+        /// <summary>Class having a set only indexer.</summary>
+        public class ClassWithSetOnlyIndexer
+        {
+            /// <summary>Indexer allowing only set.</summary>
+            public bool this[int i, string s] { set { } }
+        }
     }
 }
 

--- a/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
+++ b/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
@@ -234,6 +234,22 @@ namespace DocXmlUnitTests
         }
 
         [TestMethod]
+        public void XmlDocId_MemberId_GetOnlyIndexer()
+        {
+            var info = typeof(MyClass.ClassWithGetOnlyIndexer).GetProperty("Item");
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.ClassWithGetOnlyIndexer.Item(System.Int32,System.String)", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_SetOnlyIndexer()
+        {
+            var info = typeof(MyClass.ClassWithSetOnlyIndexer).GetProperty("Item");
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.ClassWithSetOnlyIndexer.Item(System.Int32,System.String)", id);
+        }
+
+        [TestMethod]
         public void XmlDocId_MemberId_IndexerWithTwoParams()
         {
             var info = typeof(MyClass).GetProperty("Item", new[] { typeof(int), typeof(string) });


### PR DESCRIPTION
This fixes a bug where DocXml would generate a wrong XML ID for set-only indexers.

The set method's last parameter is the value to set and has to be skipped when generating the XML ID. The current implementation wrongly skips the _first_ parameter.

Also adds tests for this case and removes some superfluous white space.