### PR TITLE
Fix XML ID generation of methods using generic parameters from class

### DIFF
--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -113,7 +113,7 @@ namespace LoxSmoke.DocXml
                 {
                     return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." +
                            propertyInfo.Name +
-                           GetParametersXmlId(setParameters.Skip(1));
+                           GetParametersXmlId(setParameters.Take(setParameters.Length - 1), GetGenericClassParams(propertyInfo));
                 }
             }
             return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." + propertyInfo.Name;
@@ -199,7 +199,7 @@ namespace LoxSmoke.DocXml
                 var index = fullTypeName.IndexOf("[,");
                 var lastIndex = fullTypeName.IndexOf(']', index);
                 fullTypeName = fullTypeName.Substring(0, index + 1) +
-                    string.Join(",", Enumerable.Repeat("0:", lastIndex - index)) + 
+                    string.Join(",", Enumerable.Repeat("0:", lastIndex - index)) +
                     fullTypeName.Substring(lastIndex);
             }
             return fullTypeName;
@@ -247,7 +247,6 @@ namespace LoxSmoke.DocXml
                 (methodInfo.Name != "op_Explicit" && methodInfo.Name != "op_Implicit")) return "";
             return "~" + GetTypeXmlId((methodInfo as MethodInfo).ReturnType);
         }
-
 
         /// <summary>
         /// Get method name. Some methods have special names or like generic methods some extra information.

--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -113,7 +113,7 @@ namespace LoxSmoke.DocXml
                 {
                     return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." +
                            propertyInfo.Name +
-                           GetParametersXmlId(setParameters.Take(setParameters.Length - 1), GetGenericClassParams(propertyInfo));
+                           GetParametersXmlId(setParameters.Take(setParameters.Length - 1));
                 }
             }
             return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." + propertyInfo.Name;

--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -113,7 +113,7 @@ namespace LoxSmoke.DocXml
                 {
                     return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." +
                            propertyInfo.Name +
-                           GetParametersXmlId(setParameters.Skip(1));
+                           GetParametersXmlId(setParameters.Skip(1), GetGenericClassParams(propertyInfo));
                 }
             }
             return PropertyPrefix + ":" + GetTypeXmlId(propertyInfo.DeclaringType) + "." + propertyInfo.Name;

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -285,6 +285,20 @@ namespace DocXmlUnitTests
         {
             public int Item { set { _ = value; } }
         }
+
+        /// <summary>Class having a get only indexer.</summary>
+        public class ClassWithGetOnlyIndexer
+        {
+            /// <summary>Indexer allowing only get.</summary>
+            public bool this[int i, string s] { get => true; }
+        }
+
+        /// <summary>Class having a set only indexer.</summary>
+        public class ClassWithSetOnlyIndexer
+        {
+            /// <summary>Indexer allowing only set.</summary>
+            public bool this[int i, string s] { set { } }
+        }
     }
 }
 

--- a/test/DocXmlUnitTests/TestData/MyTemplateClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyTemplateClass.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+namespace DocXmlUnitTests.TestData
+{
+    /// <summary>Class having generic type parameters.</summary>
+    public class MyTemplateClass<T0, T1>
+    {
+        /// <summary>Template class ctor</summary>
+        public MyTemplateClass() { }
+
+        /// <summary>Method using generic type parameters of class.</summary>
+        public void Foo(T0 a, List<T1> b) { }
+
+        /// <summary>Method with own generic type parameters.</summary>
+        public void Bar<T2, T3>(T2 a, List<T3> b) { }
+
+        /// <summary>Method mixing generic type parameters of class and method.</summary>
+        public void Qux<T2, T3>(T0 a, List<T1> b, T2 c, List<T3> d) { }
+
+        /// <summary>Indexer using generic type parameters of class.</summary>
+        public T0 this[T0 a, List<T1> b]
+        {
+            get { return default; }
+            set { }
+        }
+
+        /// <summary>Nested class having generic type parameters.</summary>
+        public class MyNestedTemplateClass<T2, T3>
+        {
+            /// <summary>Method mixing generic type parameters of parent class, nested class, and method.</summary>
+            public void Baz<T4, T5>(T0 a, List<T1> b, T2 c, List<T3> d, T4 e, List<T5> f) { }
+        }
+    }
+}

--- a/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
+++ b/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
@@ -1,4 +1,5 @@
-﻿using LoxSmoke.DocXml;
+﻿using DocXmlUnitTests.TestData;
+using LoxSmoke.DocXml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -305,6 +306,62 @@ namespace DocXmlUnitTests
             {
                 XmlDocId.MemberId(info);
             });
+        }
+
+        [TestMethod]
+        public void XmlDocId_TypeId_TemplateClass()
+        {
+            var info = typeof(MyTemplateClass<,>);
+            var id = info.TypeId();
+            Assert.AreEqual("T:DocXmlUnitTests.TestData.MyTemplateClass`2", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateClassCtor()
+        {
+            var info = typeof(MyTemplateClass<,>).GetConstructor(Type.EmptyTypes);
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.TestData.MyTemplateClass`2.#ctor", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateClassMethodUsingClassTypeParams()
+        {
+            var info = typeof(MyTemplateClass<,>).GetMethod("Foo");
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.TestData.MyTemplateClass`2.Foo(`0,System.Collections.Generic.List{`1})", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateClassMethodUsingOnlyOwnTypeParams()
+        {
+            var info = typeof(MyTemplateClass<,>).GetMethod("Bar");
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.TestData.MyTemplateClass`2.Bar``2(``0,System.Collections.Generic.List{``1})", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateClassMethodMixingTypeParamsFromClassAndMethod()
+        {
+            var info = typeof(MyTemplateClass<,>).GetMethod("Qux");
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.TestData.MyTemplateClass`2.Qux``2(`0,System.Collections.Generic.List{`1},``0,System.Collections.Generic.List{``1})", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateClassIndexerUsingClassTypeParams()
+        {
+            var info = typeof(MyTemplateClass<,>).GetProperty("Item");
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.TestData.MyTemplateClass`2.Item(`0,System.Collections.Generic.List{`1})", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_NestedTemplateClassMethodMixingTypeParamsFromParentClassNestedClassAndMethod()
+        {
+            var info = typeof(MyTemplateClass<,>.MyNestedTemplateClass<,>).GetMethod("Baz");
+            var id = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.TestData.MyTemplateClass`2.MyNestedTemplateClass`2.Baz``2(`0,System.Collections.Generic.List{`1},`2,System.Collections.Generic.List{`3},``0,System.Collections.Generic.List{``1})", id);
         }
     }
 }

--- a/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
+++ b/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
@@ -234,6 +234,22 @@ namespace DocXmlUnitTests
         }
 
         [TestMethod]
+        public void XmlDocId_MemberId_GetOnlyIndexer()
+        {
+            var info = typeof(MyClass.ClassWithGetOnlyIndexer).GetProperty("Item");
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.ClassWithGetOnlyIndexer.Item(System.Int32,System.String)", id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_SetOnlyIndexer()
+        {
+            var info = typeof(MyClass.ClassWithSetOnlyIndexer).GetProperty("Item");
+            var id = info.MemberId();
+            Assert.AreEqual("P:DocXmlUnitTests.MyClass.ClassWithSetOnlyIndexer.Item(System.Int32,System.String)", id);
+        }
+
+        [TestMethod]
         public void XmlDocId_MemberId_IndexerWithTwoParams()
         {
             var info = typeof(MyClass).GetProperty("Item", new[] { typeof(int), typeof(string) });


### PR DESCRIPTION
This fixes a bug where DocXml would generate a wrong XML ID for methods that use generic parameters of the enclosing class.

Only when the generic parameters are from the method itself the double backticks are needed for the reference (e.g. ``` ``1 ```). When the generic parameter comes from the class containing the method then a single backtick needs to be used (e.g. `` `1 ``).

This should be reviewed after merging [my other PR](https://github.com/loxsmoke/DocXml/pull/10) for a slightly shorter diff.