### PR TITLE
Preserve whitespace of XML so indent can be calculated correctly

### DIFF
--- a/src/DocXml/DocXmlReader.cs
+++ b/src/DocXml/DocXmlReader.cs
@@ -56,7 +56,7 @@ namespace LoxSmoke.DocXml
         /// <param name="unindentText">True if extra leading spaces should be removed from comments</param>
         public DocXmlReader(string fileName, bool unindentText = true)
         {
-            var document = new XPathDocument(fileName);
+            var document = new XPathDocument(fileName, XmlSpace.Preserve);
             navigator = document.CreateNavigator();
             UnIndentText = unindentText;
         }
@@ -316,7 +316,7 @@ namespace LoxSmoke.DocXml
                 assemblyNavigators.Add(assembly, null);
                 return null;
             }
-            var document = new XPathDocument(commentFileName);
+            var document = new XPathDocument(commentFileName, XmlSpace.Preserve);
             var docNavigator = document.CreateNavigator();
             assemblyNavigators.Add(assembly, docNavigator);
             return docNavigator;

--- a/test/DocXmlUnitTests/DocXmlReaderUnitTests.cs
+++ b/test/DocXmlUnitTests/DocXmlReaderUnitTests.cs
@@ -40,5 +40,20 @@ namespace DocXmlUnitTests
             Assert.IsNotNull(mm.Remarks);
             Assert.IsNotNull(mm.Example);
         }
+
+        [TestMethod]
+        public void DocXmlReader_AutoName_PreservesWhitespace()
+        {
+            var doc = new DocXmlReader((a) => Path.GetFileNameWithoutExtension(a.Location) + ".xml");
+            var summary = doc.GetMemberComment(typeof(MyClass).GetMethod(nameof(MyClass.MemberFunctionWithParaTagsInSummary)));
+            Assert.AreEqual(
+@"<para>
+First paragraph.
+</para>
+<para>
+Second paragraph.
+</para>",
+                summary);
+        }
     }
 }

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -154,6 +154,16 @@ namespace DocXmlUnitTests
             => outArrayOfListOfInt = new[] { new List<float>() };
 
         /// <summary>
+        /// <para>
+        /// First paragraph.
+        /// </para>
+        /// <para>
+        /// Second paragraph.
+        /// </para>
+        /// </summary>
+        public void MemberFunctionWithParaTagsInSummary() { }
+
+        /// <summary>
         /// Delegate type description
         /// </summary>
         /// <param name="parameter">Parameter description</param>


### PR DESCRIPTION
# TL;DR

The `XPathDocument` class changes the indentation of the XML when node contents are retrieved via `InnerXml`/`OuterXml`. This leads to problems during indent calculation when `<para>` tags are used inside comments.

# Long explanation

Using `<para>` tags inside XML comments is useful to add line breaks in IntelliSense (which ignores regular line breaks). Here is an example:

![image](https://user-images.githubusercontent.com/1454629/81312991-94d20d00-9087-11ea-9f16-e0c3f41fecc2.png)

Now consider the following class where the XML comment of method `Bar()` has `<para>` tags:

```csharp
public class MyClass {
    /// <summary>
    /// First paragraph.
    /// 
    /// Second paragraph.
    /// </summary>
    public void Foo() { }

    /// <summary>
    /// <para>
    /// First paragraph.
    /// </para>
    /// <para>
    /// Second paragraph.
    /// </para>
    /// </summary>
    public void Bar() { }
}
```

This will produce the following XML documentation:

```xml
        <member name="M:DocXmlUnitTests.MyClass.Foo">
            <summary>
            First paragraph.
            
            Second paragraph.
            </summary>
        </member>
        <member name="M:DocXmlUnitTests.MyClass.Bar">
            <summary>
            <para>
            First paragraph.
            </para>
            <para>
            Second paragraph.
            </para>
            </summary>
        </member>
```

When retrieving the comments for `Foo()` the current implementation of DocXml will use the following `OuterXml`...

```xml
<summary>
            First paragraph.
            
            Second paragraph.
            </summary>
```

...to correctly calculate the indentation and fix the `InnerXml` to look like this:

```xml
First paragraph.

Second paragraph.
```

However for `Bar()` the `OuterXml` will look like this:

```xml
<summary>
  <para>
            First paragraph.
            </para>
  <para>
            Second paragraph.
            </para>
</summary>
```

Which leads to an incorrectly calculated indent that in turn causes the result to look like this:

```xml
<para>
            First paragraph.
            </para>
<para>
            Second paragraph.
            </para>
```

With the proposed patch the `OuterXml` will be retrieved exactly as is from the XML file...

```xml
<summary>
            <para>
            First paragraph.
            </para>
            <para>
            Second paragraph.
            </para>
            </summary>
```

...and can then be correctly un-indented to this:

```xml
<para>
First paragraph.
</para>
<para>
Second paragraph.
</para>
```

Note that I'm currently preparing a pull request for mddox which will turn `<para>` tags into line breaks. But for it to work this change is needed in DocXml.

I know... lots of text for such a small PR, but I felt a proper explanation was necessary.