### PR TITLE
fix the error of this method 'GetTypeXmlId'

### DIFF
--- a/src/DocXml/XmlDocId.cs
+++ b/src/DocXml/XmlDocId.cs
@@ -190,6 +190,19 @@ namespace LoxSmoke.DocXml
             {
                 fullTypeName = $"{typeNamespace}{type.DeclaringType.Name}.{type.Name}{outString}";
             }
+            else if (type.ContainsGenericParameters && type.IsArray)
+            {
+                var paramString = GetTypeXmlId(type.GetElementType(), isOut: false, isMethodParameter,
+                                               genericClassParams);
+
+                var typeName = paramString + "[]";
+                fullTypeName = $"{typeName}{outString}";
+            }
+            else if (type.ContainsGenericParameters && type.GetElementType() != null)
+            {
+                var typeName = GetTypeXmlId(type.GetElementType(), isOut: false, isMethodParameter, genericClassParams);
+                fullTypeName = $"{typeName}{outString}";
+            }
             else
             {
                 fullTypeName = $"{typeNamespace}{type.Name}{outString}";

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -279,6 +279,26 @@ namespace DocXmlUnitTests
         }
 
         /// <summary>
+        /// TemplateMethod5 description 
+        /// </summary>
+        /// <param name="parameter">parameter description</param>
+        public void TemplateMethod5<T>(params T[] parameter)
+        {
+
+        }
+
+        /// <summary>
+        /// TemplateMethod6 description 
+        /// </summary>
+        /// <param name="parameter1">parameter1 description</param>
+        /// <param name="parameter2">parameter2 description</param>
+        public bool TemplateMethod6<TEnum>(object parameter1, out TEnum parameter2) where TEnum : struct//, Enum 
+        {
+            parameter2 = default;
+            return false;
+        }
+
+        /// <summary>
         /// GetSetProperty comment
         /// </summary>
         /// <returns>prop return</returns>

--- a/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
+++ b/test/DocXmlUnitTests/XmlDocIdUnitTests.cs
@@ -211,6 +211,23 @@ namespace DocXmlUnitTests
         }
 
         [TestMethod]
+        public void XmlDocId_MemberId_TemplateMethodWithGenericParamsArray()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.TemplateMethod5));
+            var id   = info.MemberId();
+
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.TemplateMethod5``1(``0[])",id);
+        }
+
+        [TestMethod]
+        public void XmlDocId_MemberId_TemplateMethodWithGenericOutParam()
+        {
+            var info = typeof(MyClass).GetMethod(nameof(MyClass.TemplateMethod6));
+            var id   = info.MemberId();
+            Assert.AreEqual("M:DocXmlUnitTests.MyClass.TemplateMethod6``1(System.Object,``0@)", id);
+        }
+
+        [TestMethod]
         public void XmlDocId_MemberId_Property()
         {
             var info = typeof(MyClass).GetMember(nameof(MyClass.GetSetProperty)).First();


### PR DESCRIPTION
There are some errors in ‘XmlDocId’ when the parameters contain optional generic parameters, or generic output parameters.