### PR TITLE
Fixed issue handling non-int32 enum types

### DIFF
--- a/src/DocXml/DocXml.csproj
+++ b/src/DocXml/DocXml.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>3.4.4.0</AssemblyVersion>
-    <FileVersion>3.4.4.0</FileVersion>
-    <Version>3.4.4</Version>
+    <AssemblyVersion>3.4.5.0</AssemblyVersion>
+    <FileVersion>3.4.5.0</FileVersion>
+    <Version>3.4.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LoxSmoke.DocXml</PackageId>
     <Authors>LoxSmoke</Authors>

--- a/src/DocXml/DocXmlReader.cs
+++ b/src/DocXml/DocXmlReader.cs
@@ -237,8 +237,9 @@ namespace LoxSmoke.DocXml
                 var valueComment = new EnumValueComment()
                 {
                     Name = enumName,
-                    Value = (int) Enum.Parse(enumType, enumName)
+                    ValueObject = Convert.ChangeType(Enum.Parse(enumType, enumName), Enum.GetUnderlyingType(enumType))
                 };
+                valueComment.Value = valueComment.ValueObject as int? ?? 0;
                 comments.ValueComments.Add(valueComment);
                 GetCommonComments(valueComment, valueNode);
             }

--- a/src/DocXml/EnumValueComment.cs
+++ b/src/DocXml/EnumValueComment.cs
@@ -16,9 +16,17 @@ namespace LoxSmoke.DocXml
         public string Name { get; set; }
 
         /// <summary>
-        /// Integer value of the enum
+        /// Integer value of the enum, if the enum is the default (int32) base type; otherwise, returns 0.
         /// </summary>
+        /// <remarks>
+        /// Use <see cref="ValueObject"/> to get the base integer value regardless of integer type.
+        /// </remarks>
         public int Value { get; set; }
+
+        /// <summary>
+        /// Integer value of the enum, whether signed or unsigned, or 8, 16, 32, or 64 bits in length.
+        /// </summary>
+        public object ValueObject { get; set; }
 
         /// <summary>
         /// Debugging-friendly text.
@@ -26,7 +34,7 @@ namespace LoxSmoke.DocXml
         /// <returns></returns>
         public override string ToString()
         {
-            return $"{(Name??"")}={Value}" + (Summary != null ? $" {Summary}" : "");
+            return $"{(Name??"")}={ValueObject??Value}" + (Summary != null ? $" {Summary}" : "");
         }
     }
 }

--- a/test/DocXmlUnitTests/EnumCommentsUnitTests.cs
+++ b/test/DocXmlUnitTests/EnumCommentsUnitTests.cs
@@ -11,6 +11,10 @@ namespace DocXmlUnitTests
     public class EnumCommentsUnitTests : BaseTestClass
     {
         public Type TestEnum2_Type;
+        public Type TestEnumUInt8_Type;
+        public Type TestEnumUInt64_Type;
+        public Type TestEnumInt64_Type;
+        public Type TestEnumWithNegativeValues_Type;
         public Type TestEnumWithValueComments_Type;
         public Type TestEnumWNoComments_Type;
 
@@ -19,6 +23,10 @@ namespace DocXmlUnitTests
         {
             base.Setup();
             TestEnum2_Type = typeof(TestEnum2);
+            TestEnumUInt8_Type = typeof(TestEnumUInt8);
+            TestEnumUInt64_Type = typeof(TestEnumUInt64);
+            TestEnumInt64_Type = typeof(TestEnumInt64);
+            TestEnumWithNegativeValues_Type = typeof(TestEnumWithNegativeValues);
             TestEnumWithValueComments_Type = typeof(TestEnumWithValueComments);
             TestEnumWNoComments_Type = typeof(MyNoCommentClass.TestEnumNoComments);
         }
@@ -98,6 +106,48 @@ namespace DocXmlUnitTests
             Assert.AreEqual("Other enum", mm.Summary);
             Assert.AreEqual(1, mm.ValueComments.Count);
             AssertEnumComment(1, "Value1", "Enum value one", mm.ValueComments[0]);
+        }
+
+        [TestMethod]
+        public void EnumType_WithValues_UInt8()
+        {
+            var mm = Reader.GetEnumComments(TestEnumUInt8_Type);
+            Assert.AreEqual(2, mm.ValueComments.Count);
+            AssertEnumComment(0, "Value1", "Enum value one", mm.ValueComments[0]);
+            AssertEnumComment(0, "Value2", "Enum value two", mm.ValueComments[1]);
+            Assert.AreEqual((byte)10, mm.ValueComments[0].ValueObject);
+            Assert.AreEqual((byte)20, mm.ValueComments[1].ValueObject);
+        }
+
+        [TestMethod]
+        public void EnumType_WithValues_UInt64()
+        {
+            var mm = Reader.GetEnumComments(TestEnumUInt64_Type);
+            Assert.AreEqual(2, mm.ValueComments.Count);
+            AssertEnumComment(0, "Value1", "Enum value one", mm.ValueComments[0]);
+            AssertEnumComment(0, "Value2", "Enum value two", mm.ValueComments[1]);
+            Assert.AreEqual(10UL, mm.ValueComments[0].ValueObject);
+            Assert.AreEqual(20UL, mm.ValueComments[1].ValueObject);
+        }
+
+        [TestMethod]
+        public void EnumType_WithValues_Int64()
+        {
+            var mm = Reader.GetEnumComments(TestEnumInt64_Type);
+            Assert.AreEqual(2, mm.ValueComments.Count);
+            AssertEnumComment(0, "Value1", "Enum value one", mm.ValueComments[0]);
+            AssertEnumComment(0, "Value2", "Enum value two", mm.ValueComments[1]);
+            Assert.AreEqual(10L, mm.ValueComments[0].ValueObject);
+            Assert.AreEqual(20L, mm.ValueComments[1].ValueObject);
+        }
+
+        [TestMethod]
+        public void EnumType_WithNegativeValues()
+        {
+            var mm = Reader.GetEnumComments(TestEnumWithNegativeValues_Type);
+            Assert.AreEqual(2, mm.ValueComments.Count);
+            AssertEnumComment(-20, "Value1", "Enum value one", mm.ValueComments[0]);
+            AssertEnumComment(-10, "Value2", "Enum value two", mm.ValueComments[1]);
         }
     }
 }

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -20,6 +20,70 @@ namespace DocXmlUnitTests
     };
 
     /// <summary>
+    /// Enum type description
+    /// </summary>
+    public enum TestEnumUInt8 : byte
+    {
+        /// <summary>
+        /// Enum value one
+        /// </summary>
+        Value1 = 10,
+        
+        /// <summary>
+        /// Enum value two
+        /// </summary>
+        Value2 = 20
+    };
+
+    /// <summary>
+    /// Enum type description
+    /// </summary>
+    public enum TestEnumUInt64 : ulong
+    {
+        /// <summary>
+        /// Enum value one
+        /// </summary>
+        Value1 = 10,
+        
+        /// <summary>
+        /// Enum value two
+        /// </summary>
+        Value2 = 20
+    };
+
+    /// <summary>
+    /// Enum type description
+    /// </summary>
+    public enum TestEnumInt64 : long
+    {
+        /// <summary>
+        /// Enum value one
+        /// </summary>
+        Value1 = 10,
+        
+        /// <summary>
+        /// Enum value two
+        /// </summary>
+        Value2 = 20
+    };
+
+    /// <summary>
+    /// Enum type description
+    /// </summary>
+    public enum TestEnumWithNegativeValues
+    {
+        /// <summary>
+        /// Enum value one
+        /// </summary>
+        Value1 = -20,
+        
+        /// <summary>
+        /// Enum value two
+        /// </summary>
+        Value2 = -10
+    };
+
+    /// <summary>
     /// Enum 2 type description
     /// </summary>
     public enum TestEnum2


### PR DESCRIPTION
Update to handle non-int32 enum types correctly. E.g., this:

```csharp
public enum TestEnumInt64 : long
{
  Value1
  Value2
}
```

was failing with:
```
System.InvalidCastException : Unable to cast object of type 'TestEnumInt64' to type 'System.Int32'.
```

This adds a new `EnumValueComment.ValueObject` that captures the underlying integer value, and `.Value` will be 0 if not an integer.