### PR TITLE
Fix invalid cast on enums

### DIFF
--- a/src/DocXml/DocXmlReader.cs
+++ b/src/DocXml/DocXmlReader.cs
@@ -237,7 +237,7 @@ namespace LoxSmoke.DocXml
                 var valueComment = new EnumValueComment()
                 {
                     Name = enumName,
-                    Value = (int) Enum.Parse(enumType, enumName)
+                    Value = Convert.ToInt32(Enum.Parse(enumType, enumName))
                 };
                 comments.ValueComments.Add(valueComment);
                 GetCommonComments(valueComment, valueNode);


### PR DESCRIPTION
I've had an Invalid cast crash when running mddox on the following code:

```c#
public enum MyBinaryEnum : uint  {
            /// <summary>Mode 1</summary>
            Mode1 = 1 << 1,
            /// <summary>Mode 2</summary>
            Mode2 = 1 << 2,
}
```