### PR TITLE
Added Support for <seealso /> links

### DIFF
--- a/src/DocXml/CommonComments.cs
+++ b/src/DocXml/CommonComments.cs
@@ -33,5 +33,10 @@ namespace LoxSmoke.DocXml
         /// Full XML comment text
         /// </summary>
         public string FullCommentText { get; set; }
+
+        /// <summary>
+        /// "seealso" links.
+        /// </summary>
+        public List<SeeAlsoTag> SeeAlso { get; set; } = new();
     }
 }

--- a/src/DocXml/DocXmlReader.cs
+++ b/src/DocXml/DocXmlReader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/src/DocXml/DocXmlReader.cs
+++ b/src/DocXml/DocXmlReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -153,6 +154,27 @@ namespace LoxSmoke.DocXml
             return comments;
         }
 
+        public List<SeeAlsoTag> GetSeeAlsoTags(XPathNavigator node)
+        {
+            var list = new List<SeeAlsoTag>();
+            var childNodes = node?.Select(SeeAlsoXPath);
+            if (childNodes == null) return list;
+
+            while (childNodes.MoveNext())
+            {
+                var cref = childNodes.Current.GetAttribute(CrefAttribute, string.Empty);
+                var href = childNodes.Current.GetAttribute(HrefAttribute, string.Empty);
+                var text = GetXmlText(childNodes.Current);
+                list.Add(new SeeAlsoTag()
+                {
+                    Cref = cref,
+                    Href = href,
+                    Text = text,
+                });
+            }
+            return list;
+        }
+
         /// <summary>
         /// Return Summary comments for specified type.
         /// For Delegate types Parameters field may be returned as well.
@@ -279,11 +301,13 @@ namespace LoxSmoke.DocXml
         private const string ReturnsXPath = "returns";
         private const string InheritdocXPath = "inheritdoc";
         private const string ExceptionXPath = "exception";
+        private const string SeeAlsoXPath = "seealso";
 
         //  XML attribute names
         private const string NameAttribute = "name";
         private const string CodeAttribute = "code";
         private const string CrefAttribute = "cref";
+        private const string HrefAttribute = "href";
         #endregion
 
         #region XML helper functions
@@ -295,6 +319,7 @@ namespace LoxSmoke.DocXml
             comments.Remarks = GetRemarksComment(rootNode);
             comments.Example = GetExampleComment(rootNode);
             comments.Inheritdoc = GetInheritdocTag(rootNode);
+            comments.SeeAlso = GetSeeAlsoTags(rootNode);
         }
 
         private XPathNavigator GetXmlMemberNode(string name, Type typeForAssembly, bool searchAllCurrentFiles = false)
@@ -307,7 +332,7 @@ namespace LoxSmoke.DocXml
             var node = GetXmlMemberNodeFromDictionary(name, typeForAssembly);
             if (node != null ||
                 !searchAllCurrentFiles ||
-                assemblyNavigators.Count <= 1 && typeForAssembly != null) 
+                assemblyNavigators.Count <= 1 && typeForAssembly != null)
                 return node;
 
             return assemblyNavigators.Values
@@ -414,7 +439,7 @@ namespace LoxSmoke.DocXml
             if (rootNode == null) return null;
             var inheritdoc = GetNamedComments(rootNode, InheritdocXPath, CrefAttribute);
             if (inheritdoc.Count == 0) return null;
-            return new InheritdocTag() {Cref = inheritdoc.First().Name};
+            return new InheritdocTag() { Cref = inheritdoc.First().Name };
         }
 
         private bool NeedsResolving(CommonComments comments)
@@ -425,8 +450,8 @@ namespace LoxSmoke.DocXml
                    string.IsNullOrEmpty(comments.Example);
         }
 
-        private bool GetCrefComments(string cref, Type typeForAssembly, CommonComments comments, 
-            Action<XPathNavigator> getCommentAction) 
+        private bool GetCrefComments(string cref, Type typeForAssembly, CommonComments comments,
+            Action<XPathNavigator> getCommentAction)
         {
             if (string.IsNullOrEmpty(cref)) return false;
             var typeNode = GetXmlMemberNode(cref, typeForAssembly, true);
@@ -443,13 +468,13 @@ namespace LoxSmoke.DocXml
                 comments?.Parameters?.Count > 0 ||
                 !string.IsNullOrEmpty(comments?.Returns) ||
                 comments?.Responses?.Count > 0 ||
-                comments?.TypeParameters?.Count > 0) 
+                comments?.TypeParameters?.Count > 0)
                 return comments;
 
             // If an explicit cref attribute is specified, the documentation from 
             // the specified namespace/type/member is inherited.
-            if (GetCrefComments(comments.Inheritdoc.Cref, methodInfo.ReflectedType, comments, 
-                (node) => GetComments(methodInfo, comments, node))) 
+            if (GetCrefComments(comments.Inheritdoc.Cref, methodInfo.ReflectedType, comments,
+                (node) => GetComments(methodInfo, comments, node)))
                 return comments;
 
             // For constructors:
@@ -464,7 +489,7 @@ namespace LoxSmoke.DocXml
                 while (baseClass != null)
                 {
                     var baseConstructor = baseClass.GetConstructor(
-                        BindingFlags.Public| BindingFlags.NonPublic| BindingFlags.Instance,
+                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                         null, CallingConventions.Any, constructorSignature, null);
                     if (baseConstructor != null)
                     {
@@ -519,13 +544,13 @@ namespace LoxSmoke.DocXml
         private TypeComments ResolveInheritdocComments(TypeComments comments, Type type)
         {
             if (!NeedsResolving(comments) ||
-                comments?.Parameters?.Count > 0) 
+                comments?.Parameters?.Count > 0)
                 return comments;
 
             // If an explicit cref attribute is specified, the documentation from
             // the specified namespace/type/member is inherited. 
             if (GetCrefComments(comments.Inheritdoc.Cref, type, comments,
-                (node) => GetComments(type, comments, node))) 
+                (node) => GetComments(type, comments, node)))
                 return comments;
 
             // For types and interfaces:

--- a/src/DocXml/SeeAlsoTag.cs
+++ b/src/DocXml/SeeAlsoTag.cs
@@ -1,0 +1,23 @@
+﻿namespace LoxSmoke.DocXml
+{
+    /// <summary>
+    /// Seealso tag with optional cref and href attributes.
+    /// </summary>
+    public class SeeAlsoTag
+    {
+        /// <summary>
+        /// Cref attribute value. This value is optional.
+        /// </summary>
+        public string Cref { get; set; }
+
+        /// <summary>
+        /// Href attribute value. This value is optional.
+        /// </summary>
+        public string Href { get; set; }
+
+        /// <summary>
+        /// The title, if any, for this link.
+        /// </summary>
+        public string Text { get; set; }
+    }
+}

--- a/test/DocXmlUnitTests/TestData/MyClass.cs
+++ b/test/DocXmlUnitTests/TestData/MyClass.cs
@@ -97,6 +97,8 @@ namespace DocXmlUnitTests
     /// <summary>
     /// This is MyClass
     /// </summary>
+    /// <seealso cref="MyClass.Nested"/>
+    /// <seealso href="https://github.com/loxsmoke/DocXml">DocXml GitHub</seealso>
     public class MyClass
     {
         /// <summary>
@@ -134,6 +136,8 @@ namespace DocXmlUnitTests
         /// <summary>
         /// Nested class
         /// </summary>
+        /// <seealso cref="MyClass"/>
+        /// <seealso href="https://github.com/loxsmoke/DocXml">DocXml GitHub</seealso>
         public class Nested
         {
             /// <summary>

--- a/test/DocXmlUnitTests/TypeCommentsUnitTests.cs
+++ b/test/DocXmlUnitTests/TypeCommentsUnitTests.cs
@@ -85,5 +85,23 @@ namespace DocXmlUnitTests
             Assert.AreEqual("T2", comments.TypeParameters[1].Name);
             Assert.AreEqual("Type param2", comments.TypeParameters[1].Text);
         }
+
+        [TestMethod]
+        public void GetTypeComments_SeeAlso()
+        {
+            var comments = Reader.GetTypeComments(typeof(MyClass));
+            Assert.IsNotNull(comments.SeeAlso);
+            Assert.AreEqual(2, comments.SeeAlso.Count);
+
+            // Verify the <seealso cref="" /> is present
+            Assert.AreEqual("T:DocXmlUnitTests.MyClass.Nested", comments.SeeAlso[0].Cref);
+            Assert.AreEqual(string.Empty, comments.SeeAlso[0].Href);
+            Assert.AreEqual(string.Empty, comments.SeeAlso[0].Text);
+
+            // Verify the <seealso href="">Test</seealso> is present
+            Assert.AreEqual(string.Empty, comments.SeeAlso[1].Cref);
+            Assert.AreEqual("https://github.com/loxsmoke/DocXml", comments.SeeAlso[1].Href);
+            Assert.AreEqual("DocXml GitHub", comments.SeeAlso[1].Text);
+        }
     }
 }


### PR DESCRIPTION
## Description

This update adds support for `<seealso cref=""/>` and `<seealso href=""/>` links for types and members.  A new `SeeAlsoTag` type contains the `Cref`, `Href`, and `Text` for any `seealso` link encountered.


## How Has This Been Tested?

This was tested by adding `<seealso />` links to the XML docs for the `MyClass` test class, and adding a unit test which ensures the links are parsed properly.

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
